### PR TITLE
smart-lock demo update

### DIFF
--- a/android/SmartLock/app/build.gradle
+++ b/android/SmartLock/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     defaultConfig {
         applicationId "org.opendds.smartlock"
         minSdkVersion 26
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode 1
         versionName "1"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/android/SmartLock/app/src/main/java/org/opendds/smartlock/OpenDdsBridge.java
+++ b/android/SmartLock/app/src/main/java/org/opendds/smartlock/OpenDdsBridge.java
@@ -310,6 +310,10 @@ public class OpenDdsBridge extends Thread {
             return;
         }
 
+        if (participantQos == null) {
+            throw new InitOpenDDSException("ERROR: Domain participant QOS creation failed");
+        }
+
         participant = participantFactory.create_participant(
                 DOMAIN, participantQos, null, DEFAULT_STATUS_MASK.value);
 

--- a/android/SmartLock/app/src/main/java/org/opendds/smartlock/OpenDdsBridge.java
+++ b/android/SmartLock/app/src/main/java/org/opendds/smartlock/OpenDdsBridge.java
@@ -311,7 +311,7 @@ public class OpenDdsBridge extends Thread {
         }
 
         if (participantQos == null) {
-            throw new InitOpenDDSException("ERROR: Domain participant QOS creation failed");
+            throw new InitOpenDDSException("ERROR: Domain participant QOS is not initialized");
         }
 
         participant = participantFactory.create_participant(

--- a/dockerfiles/android-opendds-cross/Dockerfile
+++ b/dockerfiles/android-opendds-cross/Dockerfile
@@ -80,11 +80,11 @@ RUN wget -O cmake-3.23.1-Linux-x86_64.tar.gz \
 ENV PATH="/home/droid/cmake-3.23.1-linux-x86_64/bin:${PATH}"
 
 # Build Xerces
-RUN wget -O xerces-c-3.2.3.tar.gz \
-        https://dlcdn.apache.org//xerces/c/3/sources/xerces-c-3.2.3.tar.gz && \
-        tar xvzf xerces-c-3.2.3.tar.gz
+RUN wget -O xerces-c-3.2.4.tar.gz \
+        https://dlcdn.apache.org//xerces/c/3/sources/xerces-c-3.2.4.tar.gz && \
+        tar xvzf xerces-c-3.2.4.tar.gz
 
-RUN cd xerces-c-3.2.3 && \
+RUN cd xerces-c-3.2.4 && \
   mkdir build && cd build && \
   cmake -DCMAKE_TOOLCHAIN_FILE=/$ANDROID_NDK/build/cmake/android.toolchain.cmake \
         -DANDROID_ABI=${ANDROID_ABI} -DANDROID_PLATFORM=${ANDROID_API} \

--- a/dockerfiles/android-opendds-cross/Dockerfile
+++ b/dockerfiles/android-opendds-cross/Dockerfile
@@ -129,10 +129,7 @@ ENV RUNTIME_LIBS=${ANDROID_NDK}/toolchains/llvm/prebuilt/linux-x86_64/sysroot/us
 RUN cp ${RUNTIME_LIBS}/libc++_shared.so /home/droid/libs && \
     cp ${XERCES_LIBS}/libxerces-c-3.2.so /home/droid/libs
 
-RUN for i in libACE.so libTAO.so libTAO_AnyTypeCode.so libTAO_BiDirGIOP.so \
-              libTAO_CodecFactory.so libTAO_PI.so libTAO_PortableServer.so \
-              libACE_XML_Utils.so; do cp ${ACE_LIBS}/${i} /home/droid/libs; done
-
-RUN cp ${DDS_LIBS}/* /home/droid/libs
+RUN cp ${ACE_LIBS}/* /home/droid/libs && \
+    cp ${DDS_LIBS}/* /home/droid/libs
 
 CMD ["/bin/bash"]

--- a/dockerfiles/pi-opendds-cross/build.sh
+++ b/dockerfiles/pi-opendds-cross/build.sh
@@ -36,10 +36,10 @@ printf "\
 	set(THREADS_PTHREAD_ARG 2)\n \
 	" > ${BUILD_ROOT}/PiToolchain.cmake
 
-wget -nc https://dlcdn.apache.org//xerces/c/3/sources/xerces-c-3.2.3.tar.gz
-tar xzf xerces-c-3.2.3.tar.gz
+wget -nc https://dlcdn.apache.org//xerces/c/3/sources/xerces-c-3.2.4.tar.gz
+tar xzf xerces-c-3.2.4.tar.gz
 
-(cd xerces-c-3.2.3 && \
+(cd xerces-c-3.2.4 && \
   mkdir -p build-pi && cd build-pi && \
   cmake -DCMAKE_TOOLCHAIN_FILE=${BUILD_ROOT}/PiToolchain.cmake -DCMAKE_INSTALL_PREFIX=${BUILD_ROOT}/pi-xerces .. && \
   make && make install)


### PR DESCRIPTION
- Updated to Android 12 (API level 31) and verified operation on a Android 9 (API level 28) device
- Updated Xerces patch version from 3.2.3 to 3.2.4
- Resolved missing libTAO_AnyTypeCode.so error by updating Dockerfile to copy all the ACE_TAO library files
 